### PR TITLE
DurationMetricProcessor - pass tags from activity to duration metric

### DIFF
--- a/Common.Diagnostics/v25/DurationMetricProcessor.cs
+++ b/Common.Diagnostics/v25/DurationMetricProcessor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Diagnostics;
 using System.Text;
+using System.Linq;
 
 namespace Common
 {
@@ -16,11 +17,13 @@ namespace Common
         public override void OnEnd(Activity activity)
         {
             double duration = activity.Duration.TotalMilliseconds;
-
-            SpanDurationMetric.Record(duration,
+            TagList tags = new()
+            {
                 new Tag("span_name", activity.OperationName),
                 new Tag("status", activity.Status.ToString())
-            );
+            };
+            tags.Concat(activity.TagObjects);
+            SpanDurationMetric.Record(duration, tags);
 
             switch (activity.GetCustomProperty(ActivityCustomPropertyNames.DurationMetric))
             {


### PR DESCRIPTION
In DurationMetricProcessor, I added to the duration metric tags coming from the related activity.

```C#
public override void OnEnd(Activity activity)
{
    double duration = activity.Duration.TotalMilliseconds;
    TagList tags = new()
    {
        new Tag("span_name", activity.OperationName),
        new Tag("status", activity.Status.ToString())
    };
    tags.Concat(activity.TagObjects);
    SpanDurationMetric.Record(duration, tags);
    ...
```